### PR TITLE
Add defaults for CUPSADMIN and CUPSPASSWORD

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This Alpine-based Docker image runs a CUPS instance that is meant as an AirPrint
 * `CUPSADMIN`: the CUPS admin user you want created
 * `CUPSPASSWORD`: the password for the CUPS admin user
 
+If CUPSADMIN is not set, the default "cupsadmin" will be used. If CUPSPASSWORD is no set, the name of the admin user will be used.
+
 ### Ports/Network:
 * Must be run on host network. This is required to support multicasting which is needed for Airprint.
 

--- a/root/root/run_cups.sh
+++ b/root/root/run_cups.sh
@@ -2,6 +2,16 @@
 set -e
 set -x
 
+# Is CUPSADMIN set? If not, set to default
+if [ -z "$CUPSADMIN" ]; then
+    CUPSADMIN="cupsadmin"
+fi
+
+# Is CUPSPASSWORD set? If not, set to $CUPSADMIN
+if [ -z "$CUPSPASSWORD" ]; then
+    CUPSPASSWORD=$CUPSADMIN
+fi
+
 if [ $(grep -ci $CUPSADMIN /etc/shadow) -eq 0 ]; then
     adduser -S -G lpadmin --no-create-home $CUPSADMIN 
 fi


### PR DESCRIPTION
If the variables CUPSADMIN and/or CUPSPASSWORD are not provided on start
adding the cups admin will fail, but the container will nevertheless
start.

With this change CUPSADMIN - if missing - will be set to "cupsadmin" and
CUPSPASSWORD - if missing - will be set to the name of the cups admin.