### PR TITLE
Install hplip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN echo "http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositorie
 	gutenprint-doc \
 	gutenprint-cups \
 	ghostscript \
+	hplip \
 	avahi \
 	inotify-tools \
 	python3 \


### PR DESCRIPTION
This PR adds hplip to the image, which provides drivers and better support for [a lot of HP printers](https://developers.hp.com/hp-linux-imaging-and-printing/supported_devices/index).