### PR TITLE
Add docker-compose.yml file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.5'
+
+services:
+  cups:
+    container_name: cups
+    image: chuckcharlie/cups-avahi-airprint
+    #build: .
+    restart: always
+    network_mode: "host"
+    environment:
+      CUPSADMIN: cups
+      CUPSPASSWORD: cups
+    volumes:
+      - "./services:/services"
+      - "./config:/config"


### PR DESCRIPTION
Here's a handy docker-compose file, if you want to include it in your readme.
Your docker, when compiled manually, works also on arm64 architectures, so you should create a multiarch docker image, so that people can use pre-built images even on other architectures.

Cheers!