### PR TITLE
Generate attributes for colour and paper size

### DIFF
--- a/root/root/airprint-generate.py
+++ b/root/root/airprint-generate.py
@@ -181,6 +181,16 @@ class AirPrintGenerate(object):
                 ptype.text = 'printer-type=%s' % (hex(v['printer-type']))
                 service.append(ptype)
 
+                if attrs['color-supported']:
+                    color = Element('txt-record')
+                    color.text = 'Color=T'
+                    service.append(color)
+
+                if attrs['media-default'] == 'iso_a4_210x297mm':
+                    max_paper = Element('txt-record')
+                    max_paper.text = 'PaperMax=legal-A4'
+                    service.append(max_paper)
+
                 pdl = Element('txt-record')
                 fmts = []
                 defer = []


### PR DESCRIPTION
Currently the avahi service file generated doesn't include whether the printer can print colour or not which causes iOS to believe the printer can only print black and white. It also doesn't include the default paper size which causes iOS to default to US letter size. This PR will cause it to add the colour flag if the printer supports colour and set the paper size to A4 if that's the default paper size of the printer.