### PR TITLE
Add support for Brother laser printers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN echo -e "http://nl.alpinelinux.org/alpine/edge/testing\nhttp://dl-cdn.alpine
 	gutenprint-doc \
 	gutenprint-cups \
 	ghostscript \
+	brlaser \
 	hplip \
 	avahi \
 	inotify-tools \


### PR DESCRIPTION
This adds the `brlaser` package to the supported printers: https://pkgs.alpinelinux.org/package/edge/community/x86/brlaser

I tried adding the individually compiled `.ppd` files (from https://github.com/pdewacht/brlaser) along with the custom rasterizers, but I kept hitting too many dead ends due to _additional_ missing dependencies.

Installing the `brlaser` package solved that issue for me and I was able to add my Brother HL-2270DW printer.

For anyone else that comes across this from Google, I ended up using the `Brother HL-2220 series, using brlaser v6 (grayscale)` driver for my HL-2270DW instead of the correct driver. That's because whenever I selected the Duplex printing option on my iPad, nothing would print (even if Duplex test pages worked through CUPS). When using the correct driver, I could only print on iOS if I turned off Double-sided printing for that job.

I solved this by forcing the HL-2270DW onto a different driver (that didn't expose the duplex settings). Doing this made it so the Double-sided printing option wasn't exposed to the iOS device, and then it would properly fall back to the printer's default preferences (with Duplex enabled) and successfully print. 




