### PR TITLE
Change cupsd default conf file location

### DIFF
--- a/root/root/run_cups.sh
+++ b/root/root/run_cups.sh
@@ -30,6 +30,10 @@ if [ `ls -l /config/printers.conf 2>/dev/null | wc -l` -eq 0 ]; then
 fi
 cp /config/printers.conf /etc/cups/printers.conf
 
+if [ `ls -l /config/cupsd.conf 2>/dev/null | wc -l` -eq 0 ]; then
+    cp /etc/cups/cupsd.conf /config/cupsd.conf
+fi
+
 /usr/sbin/avahi-daemon --daemonize
 /root/printer-update.sh &
-exec /usr/sbin/cupsd -f
+exec /usr/sbin/cupsd -f -c /config/cupsd.conf


### PR DESCRIPTION
Currently, changes to the configuration file are dropped whenever the container changes. This pull request moves the configuration file inside the /config folder.